### PR TITLE
Added version to manifest.json

### DIFF
--- a/custom_components/miheater/manifest.json
+++ b/custom_components/miheater/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "miheater",
   "name": "Smartmi Smart Heater",
+  "version": "1.0.0",
   "documentation": "https://github.com/fineemb/Smartmi-smart-heater",
   "requirements": [
     "construct==2.9.45",


### PR DESCRIPTION
Integration versions are now needed or it will display an error when loading.
https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions